### PR TITLE
Introduce merge strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,34 @@ Client.load({
   * parts - `string`, variable, mandatory:
 * `forEach(callback, includeOverridden)`: Iterates over every key/value in the config.
   * callback - `function(key: string, value: string)`, mandatory: iteration callback.
-  * includeOverridden - `boolean`, optional, default=`false`: if true, include overridden keys.
+  * includeOverridden - `boolean`, optional, default=`false`: if true, include overridden keys or `replace`.
+  
+```js
+  config.get("this.is.a.key");
+  config.get("this.is", "a.key");
+  config.get("this", "is", "a", "key");
+  
+  config.forEach((key, value) => console.log(key + ":" + value));
+```
+  
 * `toString(spaces): string`: Returns a string representation of `raw` property.
   * spaces - `number`, optional: spaces to use in format.
-* `toObject(): object`: Returns the whole configuration as an object. (Since version 1.3.0)
-
+* `toObject([options]): object`: Returns the whole configuration as an object. (Since version 1.3.0).
+  * `options.overlappingArrays` — specify strategy to process overlapping arrays:
+    * `merge` — default behaviour, merge overlapping lists
+    * `replace` — use only the array from the most specific property source:
+    
 ```js
-config.get("this.is.a.key");
-config.get("this.is", "a.key");
-config.get("this", "is", "a", "key");
+// Simplified data from Spring Cloud Config:
+// [
+//  {"key01[0]" : 5}, // ← the most specific property source
+//  {"key01[0]" : "string1", "key01[1]" : "string2"}
+// ]
 
-config.forEach((key, value) => console.log(key + ":" + value));
-```
+ config.toObject({overlappingArrays:'merge'}) // {"key01[0]": 5, "key01[1]": "string2"}
+ config.toObject({overlappingArrays:'replace'}) // {"key01[0]": 5}
+``` 
+  
 
 ## Behind a proxy
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -181,7 +181,7 @@ class Config {
   /**
    * Returns the configuration as an object
    *
-   * @param {Object} options - configure the conversion process:
+   * @param {Object} [options] - configure the conversion process:
    * @param {'merge' | 'replace'} options.overlappingArrays - define strategy to deal with arrays from different
    * property sources that have the same key — merge or use the most specific(`replace`)
    *

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@
  * @return {Array<module:Spring~ConfigSource>} list of sources.
  */
 function getSources (data) {
-  return data.propertySources.map((file) => file.source)
+  return data.propertySources.map(file => ({ ...file.source }))
 }
 
 function updateCurrent (current, name, indexes, value) {
@@ -35,27 +35,53 @@ function updateCurrent (current, name, indexes, value) {
 const keyRE = /^(\S+?)(?:\[\d+\])+$/
 const indexesRE = /\[\d+\]/g
 
-function toObject (properties) {
-  const obj = {}
-  for (const key of Object.keys(properties)) {
-    let current = obj
-    let name = null
-    let indexes = []
-    for (const item of key.split('.')) {
-      current = updateCurrent(current, name, indexes, {})
-      const match = keyRE.exec(item)
-      if (match) {
-        name = match[1]
-        indexes = item.match(indexesRE)
-          .map(str => Number.parseInt(str.slice(1, -1), 10))
-      } else {
-        name = item
-        indexes = []
+/**
+ * Returns a list of keys to be used when convert Config to JS Object
+ *
+ * Provide `overlappingArrays` value to set how to process overlapping arrays from different property sources:
+ * * `merge`(default) — to merge arrays together
+ * * `replace` — use array from most specific property source
+ *
+ * **Example:**
+ * ```
+ * rawData = [
+ *  {"key01[0]" : 5},
+ *  {"key01[0]" : "string1", "key01[1]" : "string2"}
+ * ]
+ *
+ * getObjectKeys(rawData, 'merge') // ["key01[0]", "key01[1]"]
+ * getObjectKeys(rawData, 'replace') // ["key01[0]"]
+ * ```
+ *
+ * @param {module:Spring~ConfigData} rawData
+ * @param {"merge"|"replace"} overlappingArrays what strategy to use when processing overlapping arrays from different sources
+ */
+function getObjectKeys (rawData, overlappingArrays = 'merge') {
+  const sources = getSources(rawData)
+
+  if (overlappingArrays === 'replace') {
+    const replaceKeys = sources.reverse().map((source) => {
+      const keys = {}
+      for (const item in source) {
+        const match = keyRE.exec(item)
+        const name = match ? match[1] : item
+        if (!(name in keys)) {
+          keys[name] = []
+        }
+        keys[name].push(item)
       }
-    }
-    updateCurrent(current, name, indexes, properties[key])
+      return keys
+    })
+    return ([]).concat(...Object.values(Object.assign(...replaceKeys)))
   }
-  return obj
+
+  const uniqueKeysSet = sources.reduce((acc, source) => {
+    for (const item in source) {
+      acc.add(item)
+    }
+    return acc
+  }, new Set())
+  return Array.from(uniqueKeysSet)
 }
 
 function replacer (ctx) {
@@ -155,12 +181,35 @@ class Config {
   /**
    * Returns the configuration as an object
    *
+   * @param {Object} options - configure the conversion process:
+   * @param {'merge' | 'replace'} options.overlappingArrays - define strategy to deal with arrays from different
+   * property sources that have the same key — merge or use the most specific(`replace`)
+   *
    * @return {object} full configuration object
    *
    * @since 1.3.0
    */
-  toObject () {
-    return toObject(this._properties)
+  toObject (options = { overlappingArrays: 'merge' }) {
+    const obj = {}
+    for (const key of getObjectKeys(this._raw, options.overlappingArrays)) {
+      let current = obj
+      let name = null
+      let indexes = []
+      for (const item of key.split('.')) {
+        current = updateCurrent(current, name, indexes, {})
+        const match = keyRE.exec(item)
+        if (match) {
+          name = match[1]
+          indexes = item.match(indexesRE)
+            .map(str => Number.parseInt(str.slice(1, -1), 10))
+        } else {
+          name = item
+          indexes = []
+        }
+      }
+      updateCurrent(current, name, indexes, this._properties[key])
+    }
+    return obj
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,12 +2108,6 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
-    },
     "json5": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -2362,29 +2356,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "nock": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-12.0.3.tgz",
-      "integrity": "sha512-QNb/j8kbFnKCiyqi9C5DD0jH/FubFGj5rt9NQFONXwQm3IPB0CULECg/eS3AU1KgZb/6SwUa4/DTRKhVxkGABw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.13",
-        "propagate": "^2.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
     },
     "node-environment-flags": {
       "version": "1.0.6",
@@ -2996,12 +2967,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
-    },
-    "propagate": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
-      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
-      "dev": true
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "jsdoc": "^3.6.4",
     "mocha": "^7.2.0",
-    "nock": "^12.0.3",
     "nyc": "^15.0.1",
     "standard": "^14.3.4"
   }

--- a/tests/client.spec.js
+++ b/tests/client.spec.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { describe, it, before, after,afterEach, beforeEach } = require('mocha')
+const { describe, it, before, after } = require('mocha')
 const Client = require('..')
 // const nock = require('nock')
 const { equal, deepEqual, ok, rejects } = require('assert').strict
@@ -26,7 +26,7 @@ describe('Spring Cloud Configuration Node Client', function () {
     const http = require('http')
     const port = 15023
     const endpoint = 'http://localhost:' + port
-    let server;
+    let server
 
     before('start http server', function (done) {
       server = http.createServer((req, res) => {
@@ -124,8 +124,8 @@ describe('Spring Cloud Configuration Node Client', function () {
     })
 
     describe('CloudConfigClient', function () {
-      describe('forEach method', function() {
-        it('iterates over distinct configuration properties by default', async function() {
+      describe('forEach method', function () {
+        it('iterates over distinct configuration properties by default', async function () {
           const config = await Client.load({
             endpoint,
             profiles: ['test', 'timeout'],
@@ -142,7 +142,7 @@ describe('Spring Cloud Configuration Node Client', function () {
           equal(counter, 4)
         })
 
-        it('iterates over overridden configuration properties if second param set to `true`', async function() {
+        it('iterates over overridden configuration properties if second param set to `true`', async function () {
           const config = await Client.load({
             endpoint,
             profiles: ['test', 'timeout'],
@@ -169,7 +169,7 @@ describe('Spring Cloud Configuration Node Client', function () {
           })
 
           const overriddenKey = 'key01'
-          let overriddenValues = []
+          const overriddenValues = []
           config.forEach((key, value) => {
             if (key === overriddenKey) {
               overriddenValues.push(value)
@@ -187,8 +187,8 @@ describe('Spring Cloud Configuration Node Client', function () {
         })
       })
 
-      describe('toObject method', function() {
-        it('responses with JS object with all the unique keys from properties', async function() {
+      describe('toObject method', function () {
+        it('responses with JS object with all the unique keys from properties', async function () {
           const config = await Client.load({
             endpoint,
             profiles: ['test'],
@@ -202,7 +202,7 @@ describe('Spring Cloud Configuration Node Client', function () {
           })
         })
 
-        it('processes nested structures correctly', async function() {
+        it('processes nested structures correctly', async function () {
           const config = await Client.load({
             endpoint,
             profiles: ['test'],
@@ -211,7 +211,6 @@ describe('Spring Cloud Configuration Node Client', function () {
           deepEqual(config.toObject(), { data: { key01: [[1, 3], [4, 5]] } })
         })
       })
-
     })
 
     it('replaces references with a context object', async function () {
@@ -254,13 +253,13 @@ describe('Spring Cloud Configuration Node Client', function () {
     })
 
     it('works as expected', async function () {
-        basicAssertions(await Client.load({
-          endpoint,
-          rejectUnauthorized: false,
-          profiles: ['test', 'timeout'],
-          name: 'application'
-        }))
-      }
+      basicAssertions(await Client.load({
+        endpoint,
+        rejectUnauthorized: false,
+        profiles: ['test', 'timeout'],
+        name: 'application'
+      }))
+    }
     )
 
     it('rejects the connection if not authorized', async function () {
@@ -272,23 +271,23 @@ describe('Spring Cloud Configuration Node Client', function () {
     })
 
     it('supports calls via proxy agent', async function () {
-        const agent = new https.Agent()
-        const old = agent.createConnection.bind(agent)
-        let used = false
-        agent.createConnection = function (options, callback) {
-          used = true
-          return old(options, callback)
-        }
-        const config = await Client.load({
-          endpoint,
-          rejectUnauthorized: false,
-          profiles: ['test', 'timeout'],
-          name: 'application',
-          agent
-        })
-        basicAssertions(config)
-        ok(used, 'Agent must be used in the call')
-        agent.destroy()
+      const agent = new https.Agent()
+      const old = agent.createConnection.bind(agent)
+      let used = false
+      agent.createConnection = function (options, callback) {
+        used = true
+        return old(options, callback)
+      }
+      const config = await Client.load({
+        endpoint,
+        rejectUnauthorized: false,
+        profiles: ['test', 'timeout'],
+        name: 'application',
+        agent
+      })
+      basicAssertions(config)
+      ok(used, 'Agent must be used in the call')
+      agent.destroy()
     })
   })
 })

--- a/tests/fixtures.json
+++ b/tests/fixtures.json
@@ -53,7 +53,41 @@
           "key06": false,
           "key07": null,
           "key08": "${MY_OLD_PASSWORD:super.password}",
-          "key09": "${MISSING_KEY}"   
+          "key09": "${MISSING_KEY}"
+        }
+      }
+    ]
+  },
+  "OVERLAPPING_LISTS": {
+    "propertySources": [
+      {
+        "source": {
+          "key01[0]": "four",
+          "key02[0]": 1,
+          "key02[1]": 2,
+          "key02[2]": 3,
+          "key05[0][0]": 100,
+          "key05[0][1]": 101,
+          "key05[1][0]": 200
+        }
+      },
+      {
+        "source": {
+          "key01[0]": "one",
+          "key01[1]": "two",
+          "key01[2]": "three",
+          "key02[0]": 99,
+          "key05[0]": 100,
+          "key05[1][0]": 90,
+          "key05[1][1]": 80
+        }
+      },
+      {
+        "source": {
+          "key01[0]": "deepest",
+          "key02[0]": "deepest",
+          "key03[0]": 1,
+          "key03[1]": 2
         }
       }
     ]


### PR DESCRIPTION
## What

Adds an option to define merge strategy for overlapping arrays when exporting to JS Object with `toObject` method. 

User can provide `overlappingArrays` option to `toObject` to set how to process overlapping arrays from different property sources:
* `merge`(default) — to merge arrays together
* `replace` — use the array from the most specific property source

## Why

Closes #25

## How

* The non-breaking change extends existing `toObject` method with additional `options` parameter
* New private function `getObjectKeys` that returns an array of keys that need to use during the conversion:
```
rawData = [
  {"key01[0]" : 5},
  {"key01[0]" : "string1", "key01[1]" : "string2"}
]

getObjectKeys(rawData, 'merge') // ["key01[0]", "key01[1]"]
getObjectKeys(rawData, 'replace') // ["key01[0]"]
```
* Tests were refactored for better grouping, test related to the merging strategies was added
* `nock` was removed because it is not used anymore


## Notes

I bet it is possible to provide the same functionality with less data juggling. I'll appreciate if you have some ideas to make it better.